### PR TITLE
Add usage instructions, fix percentage conversion for Sass

### DIFF
--- a/intrinsic-ratio.less
+++ b/intrinsic-ratio.less
@@ -1,3 +1,4 @@
+/* Usage: .ir(16/9, 100); */
 .ir(@ratio, @width: 100) {
 	width: unit(@width, ~'%');
 	height: 0;

--- a/intrinsic-ratio.scss
+++ b/intrinsic-ratio.scss
@@ -1,5 +1,6 @@
+/* Usage: @include ir(16/9, 100); */
 @mixin ir($ratio, $width: 100) {
-	width: $width + '%';
+	width: $width * 1%;
 	height: 0;
-	padding-bottom: $width / $ratio + '%';
+	padding-bottom: ($width / $ratio) * 1%;
 }


### PR DESCRIPTION
Sass outputs a string instead of the expected percentage. This fixes that problem.

I’m not sure if the same issue exists for Less. I also added a line explaining how to use the mixins! :)
